### PR TITLE
fix: check if property exists before using them

### DIFF
--- a/src/pages/docs/main/func/[func].vue
+++ b/src/pages/docs/main/func/[func].vue
@@ -70,7 +70,7 @@
 								Returns:
 								<div class="inline-block whitespace-pre-wrap">
 									<span
-										><router-link :to="docs.Returns.Type" class="">{{ docs.Returns.Type }}</router-link></span
+										><router-link :to="docs.Returns?.Type" class="">{{ docs.Returns?.Type }}</router-link></span
 									>
 								</div>
 							</div>

--- a/src/pages/docs/main/struct/[struct].vue
+++ b/src/pages/docs/main/struct/[struct].vue
@@ -241,7 +241,7 @@ export default defineComponent({
 			const docs = await getDocsJson('main');
 			this.docsjson = docs;
 			this.docs = docs.Structures.find((struct: Doc) => struct.Name === path);
-			if (this.docs.Line.startsWith('<')) return; //return early if line is already formatted
+			if (this.docs.Line?.startsWith('<')) return; //return early if line is already formatted
 			this.docs.Line = parseMarkdownColors(this.docs.Line, 'go');
 		},
 	},


### PR DESCRIPTION
Solved errors shown below with [Optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining): 

1.
![b1](https://user-images.githubusercontent.com/36863863/153935205-b624a0da-55e8-4ae3-814c-aeb357b63768.png)
2.
![b2](https://user-images.githubusercontent.com/36863863/153935228-5c207984-2e59-4b8c-abee-6237c1e0ff97.png)

