### PR TITLE
feat: use fontawesome packages over cdn

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,18 +32,6 @@
 			property="twitter:image"
 			content="https://gominima.studio/banner.png"
 		/>
-		<link
-			rel="stylesheet"
-			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/solid.min.css"
-			crossorigin="anonymous"
-			referrerpolicy="no-referrer"
-		/>
-		<link
-			rel="stylesheet"
-			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/brands.min.css"
-			crossorigin="anonymous"
-			referrerpolicy="no-referrer"
-		/>
 		<!-- This retrieves the latest Twemoji script -->
 		<script
 			src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
+		"@fortawesome/fontawesome-svg-core": "^1.3.0",
+		"@fortawesome/free-brands-svg-icons": "^6.0.0",
+		"@fortawesome/free-solid-svg-icons": "^6.0.0",
+		"@fortawesome/vue-fontawesome": "^3.0.0-5",
 		"@tailwindcss/postcss7-compat": "^2.2.17",
 		"@vueuse/core": "^7.5.5",
 		"autoprefixer": "^10.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"@fortawesome/fontawesome-svg-core": "^1.3.0",
 		"@fortawesome/free-brands-svg-icons": "^6.0.0",
-		"@fortawesome/free-solid-svg-icons": "^6.0.0",
+		"@fortawesome/free-solid-svg-icons": "^6.0.0-beta3",
 		"@fortawesome/vue-fontawesome": "^3.0.0-5",
 		"@tailwindcss/postcss7-compat": "^2.2.17",
 		"@vueuse/core": "^7.5.5",

--- a/src/components/Easy.vue
+++ b/src/components/Easy.vue
@@ -17,7 +17,9 @@
 			<div class="mockup-code bg-code w-3/5 text-sm">
 				<pre><code class="font-fira" v-html="setupRelatedCode"></code></pre>
 			</div>
-			<div class="divider">↓</div>
+			<div class="divider">
+				<font-awesome-icon class="text-xl" :icon="['fas', 'arrow-down-long']" />
+			</div>
 			<div class="border mockup-window border-base-900w-3/5 bg-code">
 				<div
 					class="flex justify-center px-20 py-16 border-t border-base-300 text-3xl md:text-5xl font-mons"

--- a/src/components/Hero.vue
+++ b/src/components/Hero.vue
@@ -10,7 +10,10 @@ export default defineComponent({
 		<div class="text-center">
 			<div class="text-5xl tracking-tight text-base-content sm:text-5xl md:text-6xl text-center">
 				<span class="inline-flex">The</span>
-				<i class="text-7xl relative top-3 px-3 mr-2 -ml-2 fa-brands fa-golang inline-flex"></i>
+				<font-awesome-icon
+					class="text-7xl relative top-3 px-3 mr-2 -ml-2 inline-flex"
+					:icon="['fab', 'golang']"
+				/>
 				<span class="inline-flex">framework</span>
 				<span class="text-primary block">to scale</span>
 			</div>
@@ -33,14 +36,14 @@ export default defineComponent({
 			<div class="rounded-md shadow">
 				<a
 					href="https://guide.gominima.studio"
-					class="w-full flex items-center justify-center px-8 text-lg btn btn-primary border border-transparent tansition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
+					class="w-full flex items-center justify-center px-8 text-lg btn btn-primary border border-transparent transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
 				>
 					Get started
 				</a>
 			</div>
 			<div class="mt-3 sm:mt-0 sm:ml-3">
 				<router-link
-					class="w-full flex items-center justify-center px-6 text-lg btn border border-transparent tansition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case md:py-4 lg:py-0 md:text-lg md:px-6"
+					class="w-full flex items-center justify-center px-6 text-lg btn border border-transparent transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case md:py-4 lg:py-0 md:text-lg md:px-6"
 					to="/docs"
 				>
 					Documentation

--- a/src/components/Install.vue
+++ b/src/components/Install.vue
@@ -26,7 +26,7 @@
 <code class="font-fira" v-html="setupRelatedCode"></code></pre>
 		</div>
 		<a
-			class="btn btn-secondary text-lg border border-transparent tansition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
+			class="btn btn-secondary text-lg border border-transparent transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
 			href="https://guide.gominima.studio"
 		>
 			Get Started

--- a/src/components/Install.vue
+++ b/src/components/Install.vue
@@ -6,12 +6,20 @@
 			<code class="font-fira">net/http</code> with a custom handler. Use it as a
 			<code class="font-fira">net/http</code> wrapper or as an independent framework. Your choice.
 		</div>
-		<div class="text-2xl font-bold pt-2 text-center font-open">Install Minima as a Go package</div>
+
+		<div class="text-2xl font-bold pt-2 text-center font-open">
+			<font-awesome-icon class="text-xl mr-2" :icon="['fas', 'terminal']" />
+			Install Minima as a Go package
+		</div>
 		<div class="italic text-center">Run the following code in a terminal</div>
 		<div class="mockup-code bg-code w-3/5">
 			<pre data-prefix="$"><code class="font-fira">go get github.com/gominima/minima</code></pre>
 		</div>
-		<div class="text-2xl font-bold pt-2 text-center font-open">Create a simple Minima server</div>
+
+		<div class="text-2xl font-bold pt-2 text-center font-open">
+			<font-awesome-icon class="text-xl mr-2" :icon="['fas', 'file-code']" />
+			Create a simple Minima server
+		</div>
 		<div class="italic text-center">Create a Go file and get programming</div>
 		<div class="mockup-code bg-code w-3/5">
 			<pre>

--- a/src/components/TryIt.vue
+++ b/src/components/TryIt.vue
@@ -8,19 +8,19 @@
 		</div>
 		<div class="flex justify-center flex-col pt-6 space-y-3 md:space-y-0 md:flex-row md:space-x-5">
 			<a
-				class="btn btn-primary text-lg border border-transparent tansition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
+				class="btn btn-primary text-lg border border-transparent transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
 				href="https://go.dev/play/"
 			>
 				Go Playground
 			</a>
 			<a
-				class="btn btn-primary text-lg border border-transparent tansition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
+				class="btn btn-primary text-lg border border-transparent transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
 				href="https://codesandbox.io/s/gominima-starter-n7h7gm"
 			>
 				Code Sandbox
 			</a>
 			<a
-				class="btn btn-primary text-lg border border-transparent tansition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
+				class="btn btn-primary text-lg border border-transparent transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-200 normal-case"
 				href="https://www.gitpod.io/"
 			>
 				Gitpod

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -6,15 +6,20 @@ export default defineComponent({
 </script>
 
 <template>
-	<div class="flex justify-center pt-12">
+	<div
+		class="flex justify-center pt-12 transition ease-in-out transform hover:-translate-y-1 hover:scale-105 duration-150"
+	>
 		<div
-			class="flex justify-center items-center w-64 md:w-96 lg:w-96 bg-base-300 py-2 px-2 rounded-full"
+			class="flex justify-center items-center w-64 md:w-96 lg:w-96 bg-base-300 py-2 px-2 rounded-full group"
 		>
 			<div class="pt-1 pb-1 p-4 rounded-full btn-secondary font-semibold">New</div>
 			<span class="truncate text-base-content ml-2 font-open">
 				<a href="https://github.com/gominima/minima"> Version 1 has launched! 🚀 </a>
 			</span>
-			<i class="fa-solid fa-chevron-right text-white flex justify-center items-center ml-2"></i>
+			<font-awesome-icon
+				class="text-white flex justify-center items-center ml-2 transition ease-in duration-200 group-hover:flex group-hover:translate-x-1"
+				:icon="['fas', 'chevron-right']"
+			/>
 		</div>
 	</div>
 </template>

--- a/src/components/WhatsNew.vue
+++ b/src/components/WhatsNew.vue
@@ -14,7 +14,9 @@ export default defineComponent({
 		>
 			<div class="pt-1 pb-1 p-4 rounded-full btn-secondary font-semibold">New</div>
 			<span class="truncate text-base-content ml-2 font-open">
-				<a href="https://github.com/gominima/minima"> Version 1 has launched! 🚀 </a>
+				<a href="https://github.com/gominima/minima/releases" target="_blank">
+					Version 1 has launched! 🚀
+				</a>
 			</span>
 			<font-awesome-icon
 				class="text-white flex justify-center items-center ml-2 transition ease-in duration-200 group-hover:flex group-hover:translate-x-1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,5 +2,14 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
 import './index.css';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faGolang } from '@fortawesome/free-brands-svg-icons';
+import { faArrowDownLong, faChevronRight, faFileCode, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
-createApp(App).use(router).mount('#app');
+library.add(faGolang, faChevronRight, faArrowDownLong, faTerminal, faFileCode);
+
+const app = createApp(App);
+
+// eslint-disable-next-line vue/component-definition-name-casing
+app.component('font-awesome-icon', FontAwesomeIcon).use(router).mount('#app');

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,11 @@ module.exports = {
 			},
 		},
 	},
+	variants: {
+		extend: {
+			visibility: ['group-hover'],
+		},
+	},
 	daisyui: {
 		darkTheme: 'dracula',
 		lightTheme: 'cupcake',

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,37 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
+  integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==
+
+"@fortawesome/fontawesome-svg-core@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz#343fac91fa87daa630d26420bfedfba560f85885"
+  integrity sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.3.0"
+
+"@fortawesome/free-brands-svg-icons@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.0.0.tgz#c69830ec2fad38c95945867f4e6927bf33cce6f8"
+  integrity sha512-BIhsy2YeGuk8+KQwpqmyayQDWo1lvGMHsMIE+z5ApPRgV7T+zGhmNzYVoBT4IrJMC6ep5WpGrxoHX+IvNxHnkw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.3.0"
+
+"@fortawesome/free-solid-svg-icons@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.0.0.tgz#bed4a501b631c6cfa35c09830f7cb63ffca1589d"
+  integrity sha512-o4FZ1XbndcgeWNb8Wh0y+Hgf73CjmyOQowUSaqQCtgIIdS+XliSBSOwCl330wER+I6CGYE96hT27bHBPmzX2Gg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.3.0"
+
+"@fortawesome/vue-fontawesome@^3.0.0-5":
+  version "3.0.0-5"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.0-5.tgz#6251e6917198362fa56510eb256cfb6aa6d30a32"
+  integrity sha512-aNmBT4bOecrFsZTog1l6AJDQHPP3ocXV+WQ3Ogy8WZCqstB/ahfhH4CPu5i4N9Hw0MBKXqE+LX+NbUxcj8cVTw==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.3.tgz#f2564c744b387775b436418491f15fce6601f63e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,7 +70,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.3.0":
+"@fortawesome/fontawesome-common-types@^0.3.0", "@fortawesome/fontawesome-common-types@^0.3.0-beta3":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
   integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==
@@ -89,12 +89,12 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.3.0"
 
-"@fortawesome/free-solid-svg-icons@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.0.0.tgz#bed4a501b631c6cfa35c09830f7cb63ffca1589d"
-  integrity sha512-o4FZ1XbndcgeWNb8Wh0y+Hgf73CjmyOQowUSaqQCtgIIdS+XliSBSOwCl330wER+I6CGYE96hT27bHBPmzX2Gg==
+"@fortawesome/free-solid-svg-icons@^6.0.0-beta3":
+  version "6.0.0-beta3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.0.0-beta3.tgz#3c0570a6389c2e2a040479c16bd7fafe75465ad0"
+  integrity sha512-7+62D0MK5fy/mzmTNx0P4QzHWzKE4oXdUER6bvR3qzux7hpM3QNzqPAGML7iBf5LG5yYK8mnh+yHWa1KRKUfRg==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.3.0"
+    "@fortawesome/fontawesome-common-types" "^0.3.0-beta3"
 
 "@fortawesome/vue-fontawesome@^3.0.0-5":
   version "3.0.0-5"


### PR DESCRIPTION
This pull request implements better icon usage using Font Awesome packages instead of using an external CDN.

This will allow for better icon handling, including viewing all the used icons in a single file (all used icons are defined in `main.ts`) and allow us to use only the required icons (instead of importing the CDN containing _every_ icon ever) using only the required dependencies.

This PR fixes/changes the following stuff:

- Use Font Awesome packages instead of CDN.
- Update some icons.
- Use Group Hover for WhatsNew component.
